### PR TITLE
Delete feature for pokespot

### DIFF
--- a/app/policies/pokespot_policy.rb
+++ b/app/policies/pokespot_policy.rb
@@ -15,6 +15,5 @@ class PokespotPolicy < ApplicationPolicy
 
   def destroy?
     record.user == user
-
   end
 end

--- a/app/views/pokespots/show.html.erb
+++ b/app/views/pokespots/show.html.erb
@@ -4,3 +4,8 @@
 <p><%= @pokespot.price %></p>
 <p><%= @pokespot.pokemon_type %></p>
 <p><%= @pokespot.scarcity_drop_level %></p>
+
+<%= link_to "Delete Pokespot",
+            pokespot_path(@pokespot),
+            method: :delete,
+            data: { confirm: "Are you sure?" } %>

--- a/app/views/pokespots/show.html.erb
+++ b/app/views/pokespots/show.html.erb
@@ -5,7 +5,12 @@
 <p><%= @pokespot.pokemon_type %></p>
 <p><%= @pokespot.scarcity_drop_level %></p>
 
-<%= link_to "Delete Pokespot",
-            pokespot_path(@pokespot),
-            method: :delete,
-            data: { confirm: "Are you sure?" } %>
+<% if policy(@pokespot).update? %>
+  <%= link_to "Update Pokespot",  edit_pokespot_path %>
+<% end %>
+<% if policy(@pokespot).destroy? %>
+  <%= link_to "Delete Pokespot",
+              pokespot_path(@pokespot),
+              method: :delete,
+              data: { confirm: "Are you sure?" } %>
+<% end %>


### PR DESCRIPTION
Adding a Delete and Update button on the show page.
Adding the authorization setup for the button (only user who created the Pokespot can delete/update)